### PR TITLE
Default to fully expanding copied values

### DIFF
--- a/lib/clipboard.ex
+++ b/lib/clipboard.ex
@@ -157,7 +157,7 @@ defmodule Clipboard do
   end
 
   defp format(value) do
-    opts = struct(Inspect.Opts, [])
+    opts = struct(Inspect.Opts, [limit: :infinity])
     doc = Inspect.Algebra.to_doc(value, opts)
     Inspect.Algebra.format(doc, opts.width)
   end

--- a/lib/clipboard.ex
+++ b/lib/clipboard.ex
@@ -157,8 +157,7 @@ defmodule Clipboard do
   end
 
   defp format(value) do
-    opts = struct(Inspect.Opts, [limit: :infinity])
-    doc = Inspect.Algebra.to_doc(value, opts)
+    doc = Inspect.Algebra.to_doc(value, %Inspect.Opts{limit: :infinity})
     Inspect.Algebra.format(doc, opts.width)
   end
 end


### PR DESCRIPTION
I hit this today - if a struct is too big, the formatted version will be truncated. Setting that limit to `:infinity` seems like a sane default, as this was the reason I went looking for a clipboard library in the first place (that is, not wanting to deal with copying a huge struct from the terminal).

I'm happy to take time to expose the option and/or add tests if you'd prefer it.