### PR TITLE
Added paste support for Windows

### DIFF
--- a/lib/clipboard.ex
+++ b/lib/clipboard.ex
@@ -115,6 +115,11 @@ defmodule Clipboard do
     command = Application.get_env(:clipboard, :unix)[:paste] || {"xclip", ["-o"]}
     execute(command)
   end
+  
+  defp paste({:win32, _os_name}) do
+    command = Application.get_env(:clipboard, :windows)[:paste] || {"powershell", ["Get-Clipboard"]}
+    execute(command)
+  end
 
   defp paste(_unsupported_os) do
     {:error, "Unsupported operating system"}


### PR DESCRIPTION
Found a way around the pasting limitation on Windows using powershell. In theory `Set-Clipboard` could also be used for setting the clipboard for consistency but this PR just focuses on pasting.